### PR TITLE
add `evict_fn` callback to `start_link` 

### DIFF
--- a/lib/lru_cache.ex
+++ b/lib/lru_cache.ex
@@ -96,6 +96,11 @@ defmodule LruCache do
   end
 
   @doc false
+  def init({name, size, opts}) do
+    init(name, size, opts)
+  end
+
+  @doc false
   def handle_put(state = %{table: table}, key, value) do
     delete_ttl(state, key)
     uniq = insert_ttl(state, key)

--- a/test/lru_cache_test.exs
+++ b/test/lru_cache_test.exs
@@ -99,4 +99,20 @@ defmodule LruCacheTest do
     LruCache.put(:test8, 6, "test 6")
     assert nil == LruCache.get(:test8, 1, false)
   end
+
+  test "eviction callback" do
+    test_pid = self()
+    LruCache.start_link(:test9, 3, evict_fn: fn(k, v) ->
+      send(test_pid, {:evicted, k, v})
+    end)
+    LruCache.put(:test9, :a, 1)
+    LruCache.put(:test9, :b, 2)
+    LruCache.put(:test9, :c, 3)
+    LruCache.put(:test9, :d, 4)
+    LruCache.put(:test9, :e, 5)
+
+    assert_received {:evicted, :a, 1}
+    assert_received {:evicted, :b, 2}
+    refute_received {:evicted, :c, 3}
+  end
 end


### PR DESCRIPTION
This adds an `evict_fn` option to `start_link` which accepts a function to be called when a key/value is evicted from the cache due to it being full. This allows cleanup / logging / instrumentation etc to be done.

The value of the key is required to execute the callback, so another access of the ets table is required to obtain this - but this is only done when `:evict_fn` is provided. If it's not present, behaviour is as before, and no extra ets operations are done.

Note, this also adds an optional `opts` `Keyword` argument to `start_link`

Our specific use case here is caching pids based on some ID. When the process is evicted from the cache, we want to shut down the process.