### PR TITLE
get with put fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,11 @@ LruCache.get(:my_cache, "id")
 LruCache.get(:my_cache, "id", touch = false)
 LruCache.update(:my_cache, "id", "new_value", touch = false)
 LruCache.delete(:my_cache, "id")
+LruCache.get(
+  :my_cache,
+  "id",
+  _touch = false,
+  _timeout = 5000,
+  _put_fun = fn key -> key ++ "_found" end
+)
 ```

--- a/README.md
+++ b/README.md
@@ -44,11 +44,5 @@ LruCache.get(:my_cache, "id")
 LruCache.get(:my_cache, "id", touch = false)
 LruCache.update(:my_cache, "id", "new_value", touch = false)
 LruCache.delete(:my_cache, "id")
-LruCache.get(
-  :my_cache,
-  "id",
-  _touch = false,
-  _timeout = 5000,
-  _put_fun = fn key -> key ++ "_found" end
-)
+LruCache.yield(:my_cache, "id", fn key -> key ++ "_found" end)
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/lru_cache.ex
+++ b/lib/lru_cache.ex
@@ -88,10 +88,6 @@ defmodule LruCache do
   end
 
   @doc """
-  Returns the `value` associated with `key` in `cache`. If `cache` does not contain `key`,
-  first we try to run the passed `put_fun`.   """
-
-  @doc """
   Removes the entry stored under the given `key` from cache.
   """
   def delete(name, key, timeout \\ 5000),

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,10 @@ defmodule LruCache.Mixfile do
   end
 
   defp deps do
-    [{:earmark, "~> 0.1", only: :dev}, {:ex_doc, "~> 0.11", only: :dev}]
+    [
+      {:earmark, "~> 1.0", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.27", only: :dev, runtime: false}
+    ]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,12 @@
-%{"benchfella": {:hex, :benchfella, "0.2.1"},
+%{
+  "benchfella": {:hex, :benchfella, "0.2.1"},
   "con_cache": {:hex, :con_cache, "0.9.0"},
-  "earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.11.1"},
-  "exactor": {:hex, :exactor, "2.2.0"}}
+  "earmark": {:hex, :earmark, "1.4.19", "3854a17305c880cc46305af15fb1630568d23a709aba21aaa996ced082fc29d7", [:mix], [{:earmark_parser, ">= 1.4.18", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "d5a8c9f9e37159a8fdd3ea8437fb4e229eaf56d5129b9a011dc4780a4872079d"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.19", "de0d033d5ff9fc396a24eadc2fcf2afa3d120841eb3f1004d138cbf9273210e8", [:mix], [], "hexpm", "527ab6630b5c75c3a3960b75844c314ec305c76d9899bb30f71cb85952a9dc45"},
+  "ex_doc": {:hex, :ex_doc, "0.27.3", "d09ed7ab590b71123959d9017f6715b54a448d76b43cf909eb0b2e5a78a977b2", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "ee60b329d08195039bfeb25231a208749be4f2274eae42ce38f9be0538a2f2e6"},
+  "exactor": {:hex, :exactor, "2.2.0"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.2", "dc72dfe17eb240552857465cc00cce390960d9a0c055c4ccd38b70629227e97c", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "fd23ae48d09b32eff49d4ced2b43c9f086d402ee4fd4fcb2d7fad97fa8823e75"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.2.0", "b44d75e2a6542dcb6acf5d71c32c74ca88960421b6874777f79153bbbbd7dccc", [:mix], [], "hexpm", "52b2871a7515a5ac49b00f214e4165a40724cf99798d8e4a65e4fd64ebd002c1"},
+}

--- a/test/lru_cache_test.exs
+++ b/test/lru_cache_test.exs
@@ -120,13 +120,21 @@ defmodule LruCacheTest do
     refute_received {:evicted, :c, 3}
   end
 
-  test "get with put fun" do
+  test "yield" do
     assert {:ok, _} = LruCache.start_link(:test10, 5)
     assert nil == LruCache.get(:test10, :a)
-    LruCache.get(:test10, :a, true, 5000, fn _key -> 1 end)
+
+    # Inserts value returned by function if not found.
+    LruCache.yield(:test10, :a, fn _key -> 1 end)
     assert 1 == LruCache.get(:test10, :a)
-    LruCache.get(:test10, :b, true, 5000, fn _key -> nil end)
+
+    # Does not insert on nil return.
+    LruCache.yield(:test10, :b, fn _key -> nil end)
     assert nil == LruCache.get(:test10, :b)
+
+    # Does not modify value if found.
+    LruCache.put(:test10, :c, 1)
+    assert 1 == LruCache.yield(:test10, :c, fn key -> key + 1 end)
   end
 
 end

--- a/test/lru_cache_test.exs
+++ b/test/lru_cache_test.exs
@@ -119,4 +119,14 @@ defmodule LruCacheTest do
     assert_received {:evicted, :b, 2}
     refute_received {:evicted, :c, 3}
   end
+
+  test "get with put fun" do
+    assert {:ok, _} = LruCache.start_link(:test10, 5)
+    assert nil == LruCache.get(:test10, :a)
+    LruCache.get(:test10, :a, true, 5000, fn _key -> 1 end)
+    assert 1 == LruCache.get(:test10, :a)
+    LruCache.get(:test10, :b, true, 5000, fn _key -> nil end)
+    assert nil == LruCache.get(:test10, :b)
+  end
+
 end


### PR DESCRIPTION
I have a usecase where I need to `put` values if they don't exist in the cache. That pattern I have been following is
1. Filter list of keys on existence in the cache.
2. Fetch keys that don't exist from DB.
3. Store those keys with db values.

This PR allows this pattern to be inlined as one step.